### PR TITLE
Users might get confused with this in case they have installed pip as…

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ You can quickly use stringlifier via pip-installation:
 ```bash
 $ pip install stringlifier
 ```
+In case you are using the pip3 installation that comes with Python3, use pip3 instead of pip in the above command.
+```bash
+$ pip3 install stringlifier
+```
 
 API example:
 ```python


### PR DESCRIPTION
… pip3 for Python3. I have added a line stating that in case their pip installation is called with pip3, they can use that instead.

I have also added the corresponding terminal command.

## Overview
Brief description of what this PR does, and why it is needed.

### Demo
Optional. Screenshots, `curl` examples, etc.

### Notes
Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions
 * How to test this PR
 * Prefer bulleted description
 * Start after checking out this branch
 * Include any setup required, such as bundling scripts, restarting services, etc.
 * Include test case, and expected output
